### PR TITLE
Workaround for missing memalign on OS X

### DIFF
--- a/src/os.cpp
+++ b/src/os.cpp
@@ -30,3 +30,18 @@ void init_timers()
 {
   Timers::init(begin_timer, stop_timers);
 }
+
+#ifdef __MACH__
+#include <stdlib.h>
+#include <stddef.h>
+#include <gsl/gsl_assert>
+void* memalign(size_t alignment, size_t size) {
+  void* ptr {nullptr};
+  int res = posix_memalign(&ptr, alignment, size);
+  Ensures(res == 0);
+  return ptr;
+}
+void* aligned_alloc(size_t alignment, size_t size) {
+  return memalign(alignment, size);
+}
+#endif


### PR DESCRIPTION
Also needs https://github.com/hioa-cs/IncludeOS/pull/1303 to build and run on OS X